### PR TITLE
Ensure Sketchup::Http::Request is kept alive.

### DIFF
--- a/src/ae_console/features/feature_documentation.rb
+++ b/src/ae_console/features/feature_documentation.rb
@@ -99,7 +99,7 @@ module AE
           @documentation_browser.set_url(url)
         else
           # Test whether url exists (Sketchup 2017+)
-          Sketchup::Http::Request.new(url, Sketchup::Http::HEAD).start{ |request, response|
+          @request = Sketchup::Http::Request.new(url, Sketchup::Http::HEAD).start{ |request, response|
             if response.status_code == 200
               @documentation_browser.set_url(url)
             else


### PR DESCRIPTION
If the request object from `Sketchup::Http::Request.new` is held on to it might become garbage collected before it'll have time to complete. Because of this it should always be assigned to an instance or class variable for at least it's duration.